### PR TITLE
Restructure to avoid skipping blocks that don't commit properly

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -147,7 +147,7 @@ func ApplyParameters(query string, params ...interface{}) string {
 }
 
 func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *sql.DB, quit <-chan struct{}, eip155Block, homesteadBlock uint64, mut *sync.RWMutex, mempoolSlots int, indexers []Indexer) {
-	
+
 	heightGauge := metrics.NewMajorGauge("/flume/height")
 	log.Info("Processing data feed")
 	txCh := make(chan *evm.Transaction, 200)
@@ -184,8 +184,8 @@ func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *
 		case tx := <-txCh:
 			mempool_indexer(db, mempoolSlots, txCount, txDedup, tx)
 		case chainUpdate := <-csCh:
-			//UPDATELOOP:
 			var lastBatch *delivery.PendingBatch
+			UPDATELOOP:
 			for {
 				megaStatement := []string{}
 				for _, pb := range chainUpdate.Added() {
@@ -194,7 +194,7 @@ func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *
 						log.Debug("inside indexer loop", "idx", indexer, "len", len(s))
 						if err != nil {
 							log.Error("Error computing updates", "err", err.Error())
-							continue
+							continue UPDATELOOP
 						}
 						megaStatement = append(megaStatement, s...)
 					}
@@ -218,45 +218,42 @@ func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *
 								log.Error("partition error", "err", err.Error())
 								continue
 							}
-
 							megaStatement = append(megaStatement, ApplyParameters(
 								("INSERT OR REPLACE INTO cardinal_offsets(offset, partition, topic) VALUES (?, ?, ?)"), offset, partition, topic))
 						}
 					}
-
-					mut.Lock()
-					start := time.Now()
-					dbtx, err := db.BeginTx(context.Background(), nil)
-					if err != nil {
-						log.Error("Error creating a transaction", "err", err.Error())
-					}
-					if _, err := dbtx.Exec(strings.Join(megaStatement, " ; ")); err != nil {
-						dbtx.Rollback()
-						stats := db.Stats()
-						log.Warn("Failed to insert logs", "err", err.Error())
-						log.Info("SQLite Pool - Open:", stats.OpenConnections, "InUse:", stats.InUse, "Idle:", stats.Idle)
-						mut.Unlock()
-						continue
-					}
-					// log.Printf("Spent %v on %v inserts", time.Since(istart), len(statements))
-					// cstart := time.Now()
-					if err := dbtx.Commit(); err != nil {
-						stats := db.Stats()
-						log.Warn("Failed to insert logs", "err", err.Error())
-						log.Info("SQLite Pool - Open:", stats.OpenConnections, "InUse:", stats.InUse, "Idle:", stats.Idle)
-						mut.Unlock()
-						continue
-					}
+				}
+				mut.Lock()
+				start := time.Now()
+				dbtx, err := db.BeginTx(context.Background(), nil)
+				if err != nil {
+					log.Error("Error creating a transaction", "err", err.Error())
+					continue
+				}
+				if _, err := dbtx.Exec(strings.Join(megaStatement, " ; ")); err != nil {
+					dbtx.Rollback()
+					stats := db.Stats()
+					log.Warn("Failed to insert logs", "err", err.Error())
+					log.Info("SQLite Pool - Open:", stats.OpenConnections, "InUse:", stats.InUse, "Idle:", stats.Idle)
 					mut.Unlock()
-					processed = true
-					heightGauge.Update(lastBatch.Number)
-					// completionFeed.Send(chainEvent.Block.Hash)
-					// log.Printf("Spent %v on commit", time.Since(cstart))
-					log.Info("Committed Block", "number", uint64(lastBatch.Number), "hash", hexutil.Bytes(lastBatch.Hash.Bytes()), "in", time.Since(start)) // TODO: Figure out a simple way to get age
+					continue
 				}
-				if processed {
-					break
+				// log.Printf("Spent %v on %v inserts", time.Since(istart), len(statements))
+				// cstart := time.Now()
+				if err := dbtx.Commit(); err != nil {
+					stats := db.Stats()
+					log.Warn("Failed to insert logs", "err", err.Error())
+					log.Info("SQLite Pool - Open:", stats.OpenConnections, "InUse:", stats.InUse, "Idle:", stats.Idle)
+					mut.Unlock()
+					continue
 				}
+				mut.Unlock()
+				processed = true
+				heightGauge.Update(lastBatch.Number)
+				// completionFeed.Send(chainEvent.Block.Hash)
+				// log.Printf("Spent %v on commit", time.Since(cstart))
+				log.Info("Committed Block", "number", uint64(lastBatch.Number), "hash", hexutil.Bytes(lastBatch.Hash.Bytes()), "in", time.Since(start)) // TODO: Figure out a simple way to get age
+				break
 			}
 		}
 	}


### PR DESCRIPTION
I noticed in testing that some blocks were getting skipped due to errors that happened on committing. Rather than retrying the commit of that block (which admittedly may lead to hanging) that block was skipped over.

This is because when commit errors occurred, it called "continue", which I originally meant to continue on the UPDATELOOP, which would retry processing the same chainUpdate, but because that got moved inside the pending batch loop, the "continue" moved to the next pending batch and never retried the chainUpdate.

Another weird side effect of this was that if there were multiple pending batches in a single chainUpdate, the megastatement was appended to throughout the chainUpdate, but executed at the end of each pendingBatch, which was certainly not the intended behavior, though it may have functioned without any issues (though I suspect that because we've been using websockets for testing, this never arose because there were never multiple pending batches in a chain update on websockets).

It's worth noting that these changes may end up putting us in infinite loops where we cannot process a block and move on, but in general (especially during testing) that's preferable to skipping a block and not noticing if we weren't paying close attention to the logs.