### PR TITLE
Start metrics reporting before serving

### DIFF
--- a/main.go
+++ b/main.go
@@ -228,6 +228,12 @@ func main() {
 		os.Exit(1)
 	}
 	if !*exitWhenSynced {
+		if cfg.Statsd != nil {
+			publishers.StatsD(cfg.Statsd.Port, cfg.Statsd.Address, time.Duration(cfg.Statsd.Interval), cfg.Statsd.Prefix, cfg.Statsd.Minor)
+		}
+		if cfg.CloudWatch != nil {
+			publishers.CloudWatch(cfg.CloudWatch.Namespace, cfg.CloudWatch.Dimensions, int64(cfg.Chainid), time.Duration(cfg.CloudWatch.Interval), cfg.CloudWatch.Percentiles, cfg.CloudWatch.Minor)
+		}
 		if err := tm.Run(cfg.HealthcheckPort); err != nil {
 			log.Error(err.Error())
 			quit <- struct{}{}
@@ -235,12 +241,6 @@ func main() {
 			time.Sleep(time.Second)
 			os.Exit(1)
 		}
-	}
-	if cfg.Statsd != nil {
-		publishers.StatsD(cfg.Statsd.Port, cfg.Statsd.Address, time.Duration(cfg.Statsd.Interval), cfg.Statsd.Prefix, cfg.Statsd.Minor)
-	}
-	if cfg.CloudWatch != nil {
-		publishers.CloudWatch(cfg.CloudWatch.Namespace, cfg.CloudWatch.Dimensions, int64(cfg.Chainid), time.Duration(cfg.CloudWatch.Interval), cfg.CloudWatch.Percentiles, cfg.CloudWatch.Minor)
 	}
 	quit <- struct{}{}
 	logsdb.Close()


### PR DESCRIPTION
The metrics reporting code was set to start during the shutdown sequence, which is not terribly useful.