### PR TITLE
Let plugins extend trackedPrefixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,7 +142,7 @@ func main() {
 	mut := &sync.RWMutex{}
 
 	// func AquireConsumer(db *sql.DB, cfg *config.Config, resumptionTime int64)
-	consumer, _ := AquireConsumer(logsdb, cfg, *resumptionTimestampMs, !*ignoreBlockTime)
+	consumer, _ := AquireConsumer(logsdb, cfg, *resumptionTimestampMs, !*ignoreBlockTime, pl)
 	indexes := []indexer.Indexer{}
 
 	if hasBlocks {

--- a/plugins/packages/polygon/main.go
+++ b/plugins/packages/polygon/main.go
@@ -6,7 +6,7 @@ import (
 	"io"
 
 	"golang.org/x/crypto/sha3"
-
+	"regexp"
 	"github.com/openrelayxyz/cardinal-evm/crypto"
 	"github.com/openrelayxyz/cardinal-evm/rlp"
 	"github.com/openrelayxyz/cardinal-evm/common"
@@ -18,6 +18,12 @@ import (
 	"github.com/openrelayxyz/flume/plugins"
 	rpcTransports "github.com/openrelayxyz/cardinal-rpc/transports"
 )
+
+var TrackedPrefixes = []*regexp.Regexp{
+	regexp.MustCompile("c/[0-9a-z]+/b/[0-9a-z]+/br/"),
+	regexp.MustCompile("c/[0-9a-z]+/b/[0-9a-z]+/bl/"),
+	regexp.MustCompile("c/[0-9a-z]+/b/[0-9a-z]+/bs"),
+}
 
 func Initialize(cfg *config.Config, pl *plugins.PluginLoader) {
 	log.Info("Polygon plugin loaded")
@@ -38,8 +44,8 @@ func RegisterAPI(tm *rpcTransports.TransportManager, db *sql.DB, cfg *config.Con
 		cfg: cfg,
 	})
 	log.Info("PolygonBorService registered")
-	return nil	
-} 
+	return nil
+}
 
 func sealHash(header *evm.Header) (hash types.Hash) {
 	hasher := sha3.NewLegacyKeccak256()


### PR DESCRIPTION
The Kafka implementation of Cardinal streams will discard keys that don't match anything in the trackedPrefixes list, so plugins need to be able to extend the trackedPrefixes list to make sure everything is captured.

This also extends the polygon plugin to add the needed prefixes.