### PR TITLE
Bugfix/mempool indexer pruning

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"math/big"
 	"encoding/json"
+	"strings"
+	"strconv"
 
 	log "github.com/inconshreveable/log15"
 	"github.com/openrelayxyz/cardinal-evm/common"
@@ -14,6 +16,23 @@ import (
 )
 
 type DecimalOrHex uint64
+
+func (dh *DecimalOrHex) UnmarshalJSON(data []byte) error {
+	input := strings.TrimSpace(string(data))
+	if len(input) >= 2 && input[0] == '"' && input[len(input)-1] == '"' {
+		input = input[1 : len(input)-1]
+	}
+
+	value, err := strconv.ParseUint(input, 10, 64)
+	if err != nil {
+		value, err = hexutil.DecodeUint64(input)
+	}
+	if err != nil {
+		return err
+	}
+	*dh = DecimalOrHex(value)
+	return nil
+}
 
 type bigList []*big.Int
 

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -165,7 +165,6 @@ func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *
 	}
 	processed := false
 	pruneTicker := time.NewTicker(5 * time.Second)
-	txCount := 0
 	txDedup := make(map[types.Hash]struct{})
 	defer txSub.Unsubscribe()
 	db.Exec("DELETE FROM mempool.transactions WHERE 1;")
@@ -180,9 +179,9 @@ func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *
 				return
 			}
 		case <-pruneTicker.C:
-			mempool_dropLowestPrice(db, mempoolSlots, txCount, txDedup)
+			mempool_dropLowestPrice(db, mempoolSlots, txDedup)
 		case tx := <-txCh:
-			mempool_indexer(db, mempoolSlots, txCount, txDedup, tx)
+			mempool_indexer(db, mempoolSlots, txDedup, tx)
 		case chainUpdate := <-csCh:
 			var lastBatch *delivery.PendingBatch
 		UPDATELOOP:

--- a/indexer/mempool_indexer.go
+++ b/indexer/mempool_indexer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/openrelayxyz/cardinal-evm/rlp"
 	evm "github.com/openrelayxyz/cardinal-evm/types"
 	"github.com/openrelayxyz/cardinal-types"
+	"github.com/openrelayxyz/cardinal-streams/delivery"
 	"strings"
 	"time"
 )

--- a/indexer/mempool_indexer.go
+++ b/indexer/mempool_indexer.go
@@ -7,19 +7,9 @@ import (
 	"github.com/openrelayxyz/cardinal-evm/rlp"
 	evm "github.com/openrelayxyz/cardinal-evm/types"
 	"github.com/openrelayxyz/cardinal-types"
-	"github.com/openrelayxyz/cardinal-streams/delivery"
 	"strings"
 	"time"
 )
-
-
-type MempoolIndexer struct{}
-
-func (indexer *MempoolIndexer) Index(pb *delivery.PendingBatch) ([]string, error) {
-	return []string{
-		"DELETE FROM mempool.transactions WHERE (sender, nonce) IN (SELECT sender, nonce FROM transactions.transactions)",
-	}, nil
-}
 
 func mempool_dropLowestPrice(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct{}) {
 	var txCount int

--- a/indexer/mempool_indexer.go
+++ b/indexer/mempool_indexer.go
@@ -11,18 +11,28 @@ import (
 	"time"
 )
 
-func mempool_dropLowestPrice(db *sql.DB, mempoolSlots int, txCount int, txDedup map[types.Hash]struct{}) {
+
+type MempoolIndexer struct{}
+
+func (indexer *MempoolIndexer) Index(pb *delivery.PendingBatch) ([]string, error) {
+	return []string{
+		"DELETE FROM mempool.transactions WHERE (sender, nonce) IN (SELECT sender, nonce FROM transactions.transactions)",
+	}, nil
+}
+
+func mempool_dropLowestPrice(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct{}) {
+	var txCount int
 	db.QueryRow("SELECT count(*) FROM mempool.transactions;").Scan(&txCount)
 	if txCount > mempoolSlots {
 		pstart := time.Now()
-		if _, err := db.Exec("DELETE FROM mempool.transactions WHERE gasPrice < (SELECT gasPrice FROM mempool.transactions ORDER BY gasPrice LIMIT 1 OFFSET ?);", mempoolSlots); err != nil {
+		if _, err := db.Exec("DELETE FROM mempool.transactions WHERE gasPrice < (SELECT gasPrice FROM mempool.transactions ORDER BY gasPrice DESC LIMIT 1 OFFSET ?);", mempoolSlots); err != nil {
 			log.Error("Error pruning", "err", err.Error())
 		}
 		log.Debug("Pruned transactions from mempool", "transaction count", (txCount - mempoolSlots), "time", time.Since(pstart))
 	}
 }
 
-func mempool_indexer(db *sql.DB, mempoolSlots int, txCount int, txDedup map[types.Hash]struct{}, tx *evm.Transaction) []string {
+func mempool_indexer(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct{}, tx *evm.Transaction) []string {
 	txHash := tx.Hash()
 	if _, ok := txDedup[txHash]; ok {
 		return []string{}
@@ -80,21 +90,11 @@ func mempool_indexer(db *sql.DB, mempoolSlots int, txCount int, txDedup map[type
 		sender,
 		tx.Nonce(),
 	))
-	if txCount > (11 * mempoolSlots / 10) {
-		// More than 10% above mempool limit, prune some.
-		statements = append(statements, ApplyParameters(
-			"DELETE FROM mempool.transactions WHERE gasPrice < (SELECT gasPrice FROM mempool.transactions ORDER BY gasPrice LIMIT 1 OFFSET %v)",
-			mempoolSlots,
-		))
-		txCount = mempoolSlots
-	}
 	if _, err := db.Exec(strings.Join(statements, " ; ") + ";"); err != nil {
 		log.Error("Error on insert:", strings.Join(statements, " ; "), "err", err.Error())
 		return []string{}
 	}
 	txDedup[txHash] = struct{}{}
-	txCount++
-	db.QueryRow("SELECT count(*) FROM mempool.transactions;").Scan(&txCount)
 
 	return statements
 }

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func main() {
 		indexes = append(indexes, indexer.NewLogIndexer(cfg.Chainid))
 	}
 	if hasMempool {
-		indexes = append(indexes, indexer.MempoolIndexer{})
+		indexes = append(indexes, &indexer.MempoolIndexer{})
 	}
 
 	pluginIndexers := pl.Lookup("Indexer", func(v interface{}) bool {

--- a/main.go
+++ b/main.go
@@ -148,13 +148,10 @@ func main() {
 		indexes = append(indexes, indexer.NewBlockIndexer(cfg.Chainid))
 	}
 	if hasTx {
-		indexes = append(indexes, indexer.NewTxIndexer(cfg.Chainid, cfg.Eip155Block, cfg.HomesteadBlock))
+		indexes = append(indexes, indexer.NewTxIndexer(cfg.Chainid, cfg.Eip155Block, cfg.HomesteadBlock, hasMempool))
 	}
 	if hasLogs {
 		indexes = append(indexes, indexer.NewLogIndexer(cfg.Chainid))
-	}
-	if hasMempool {
-		indexes = append(indexes, &indexer.MempoolIndexer{})
 	}
 
 	pluginIndexers := pl.Lookup("Indexer", func(v interface{}) bool {

--- a/main.go
+++ b/main.go
@@ -153,6 +153,9 @@ func main() {
 	if hasLogs {
 		indexes = append(indexes, indexer.NewLogIndexer(cfg.Chainid))
 	}
+	if hasMempool {
+		indexes = append(indexes, indexer.MempoolIndexer{})
+	}
 
 	pluginIndexers := pl.Lookup("Indexer", func(v interface{}) bool {
 		_, ok := v.(func(*config.Config) indexer.Indexer)


### PR DESCRIPTION
The mempool wasn't being pruned properly, and many transactions that had been confirmed in blocks were being left in the mempool table.