### PR TITLE
Prune timed out transactions from mempool

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 	"math/big"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
@@ -54,9 +55,9 @@ type Config struct {
 	Databases       map[string]string `yaml:"databases"`
 	MempoolDb       string            `yaml:"mempoolDB"`
 	BlocksDb        string            `yaml:"blocksDB"`
-	TxDb            string            `yaml:"transactionsDB"`
 	LogsDb          string            `yaml:"logsDB"`
 	MempoolSlots    int               `yaml:"mempoolSize"`
+	MemTxTimeThreshold time.Duration           `yaml:"mempoolTxTime"` //mempool tx expiration in miuntes
 	Concurrency     int               `yaml:"concurrency"`
 	LogLevel        string            `yaml:"loggingLevel"`
 	Plugins         []string          `yaml:"plugins"`
@@ -211,11 +212,17 @@ func LoadConfig(fname string) (*Config, error) {
 			Rollback: cfg.Brokers[i].Rollback,
 		}
 	}
+	
 	if cfg.CloudWatch != nil {
 		if cfg.CloudWatch.Namespace == "" {
 			cfg.CloudWatch.Namespace = "Flume"
 		}
 	}
+	
+	if cfg.MemTxTimeThreshold == 0 {
+		cfg.MemTxTimeThreshold = 60
+	}
+	
 	return &cfg, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 	"math/big"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
@@ -57,7 +56,7 @@ type Config struct {
 	BlocksDb        string            `yaml:"blocksDB"`
 	LogsDb          string            `yaml:"logsDB"`
 	MempoolSlots    int               `yaml:"mempoolSize"`
-	MemTxTimeThreshold time.Duration           `yaml:"mempoolTxTime"` //mempool tx expiration in miuntes
+	MemTxTimeThreshold int64          `yaml:"mempoolTxTime"` //mempool tx expiration in miuntes
 	Concurrency     int               `yaml:"concurrency"`
 	LogLevel        string            `yaml:"loggingLevel"`
 	Plugins         []string          `yaml:"plugins"`

--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -180,7 +180,7 @@ func (hc *HealthCheck) Healthy() rpc.HealthStatus {
 	return rpc.Healthy
 }
 
-func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *sql.DB, quit <-chan struct{}, eip155Block, homesteadBlock uint64, mut *sync.RWMutex, mempoolSlots int, indexers []Indexer, hc *HealthCheck, memTxThreshold time.Duration) {
+func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *sql.DB, quit <-chan struct{}, eip155Block, homesteadBlock uint64, mut *sync.RWMutex, mempoolSlots int, indexers []Indexer, hc *HealthCheck, memTxThreshold int64) {
 	heightGauge := metrics.NewMajorGauge("/flume/height")
 	log.Info("Processing data feed")
 	txCh := make(chan *evm.Transaction, 200)

--- a/indexer/mempool_indexer.go
+++ b/indexer/mempool_indexer.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 )
 
-func prune_mempool(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct{}, memTxThreshold time.Duration) {
+func prune_mempool(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct{}, memTxThreshold int64) {
 	pstart := time.Now() 
-	threshold :=  pstart.Add(-memTxThreshold * time.Minute).Unix()
+	threshold :=  pstart.Add(-time.Duration(memTxThreshold) * time.Minute).Unix()
 	if _, err := db.Exec("DELETE FROM mempool.transactions WHERE time < ?;", threshold); err != nil {
 		log.Error("Error time pruning mempool", "err", err.Error())
 	}

--- a/indexer/mempool_indexer.go
+++ b/indexer/mempool_indexer.go
@@ -14,7 +14,7 @@ import (
 func prune_mempool(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct{}, memTxThreshold time.Duration) {
 	pstart := time.Now() 
 	threshold :=  pstart.Add(-memTxThreshold * time.Minute).Unix()
-	if _, err := db.Exec("DELETE FROM mempool.transactions WHERE time > ?;", threshold); err != nil {
+	if _, err := db.Exec("DELETE FROM mempool.transactions WHERE time < ?;", threshold); err != nil {
 		log.Error("Error time pruning mempool", "err", err.Error())
 	}
 	log.Debug("Pruned timed out transactions from mempool")

--- a/indexer/mempool_indexer.go
+++ b/indexer/mempool_indexer.go
@@ -1,6 +1,7 @@
 package indexer
 
 import (
+	"time"
 	"database/sql"
 
 	log "github.com/inconshreveable/log15"
@@ -8,18 +9,22 @@ import (
 	evm "github.com/openrelayxyz/cardinal-evm/types"
 	"github.com/openrelayxyz/cardinal-types"
 	"strings"
-	"time"
 )
 
-func mempool_dropLowestPrice(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct{}) {
+func prune_mempool(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct{}, memTxThreshold time.Duration) {
+	pstart := time.Now() 
+	threshold :=  pstart.Add(-memTxThreshold * time.Minute).Unix()
+	if _, err := db.Exec("DELETE FROM mempool.transactions WHERE time > ?;", threshold); err != nil {
+		log.Error("Error time pruning mempool", "err", err.Error())
+	}
+	log.Debug("Pruned timed out transactions from mempool")
 	var txCount int
 	db.QueryRow("SELECT count(*) FROM mempool.transactions;").Scan(&txCount)
 	if txCount > mempoolSlots {
-		pstart := time.Now()
 		if _, err := db.Exec("DELETE FROM mempool.transactions WHERE gasPrice < (SELECT gasPrice FROM mempool.transactions ORDER BY gasPrice DESC LIMIT 1 OFFSET ?);", mempoolSlots); err != nil {
-			log.Error("Error pruning", "err", err.Error())
+			log.Error("Error gasPrice pruning", "err", err.Error())
 		}
-		log.Debug("Pruned transactions from mempool", "transaction count", (txCount - mempoolSlots), "time", time.Since(pstart))
+		log.Debug("Pruned transactions from mempool gasPrice", "transaction count", (txCount - mempoolSlots), "time", time.Since(pstart))
 	}
 }
 
@@ -48,6 +53,7 @@ func mempool_indexer(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct
 		to = trimPrefix(tx.To().Bytes())
 	}
 	v, r, s := tx.RawSignatureValues()
+	t := time.Now()
 	statements := []string{}
 	// If this is a replacement transaction, delete any it might be replacing
 	statements = append(statements, ApplyParameters(
@@ -57,7 +63,7 @@ func mempool_indexer(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct
 	))
 	// Insert the transaction
 	statements = append(statements, ApplyParameters(
-		"INSERT INTO mempool.transactions(gas, gasPrice, hash, input, nonce, recipient, `value`, v, r, s, sender, `type`, access_list, gasFeeCap, gasTipCap) VALUES (%v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v)",
+		"INSERT INTO mempool.transactions(gas, gasPrice, hash, input, nonce, recipient, `value`, v, r, s, sender, `type`, access_list, gasFeeCap, gasTipCap, time) VALUES (%v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v, %v)",
 		tx.Gas(),
 		gasPrice,
 		txHash,
@@ -73,6 +79,7 @@ func mempool_indexer(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct
 		compress(accessListRLP),
 		trimPrefix(tx.GasFeeCap().Bytes()),
 		trimPrefix(tx.GasTipCap().Bytes()),
+		t.Unix(),
 	))
 	// Delete the transaction we just inserted if the confirmed transactions
 	// pool has a conflicting entry

--- a/main.go
+++ b/main.go
@@ -213,7 +213,7 @@ func main() {
 	}
 
 	hc := &indexer.HealthCheck{}
-	go indexer.ProcessDataFeed(consumer, txFeed, logsdb, quit, cfg.Eip155Block, cfg.HomesteadBlock, mut, cfg.MempoolSlots, indexes, hc)
+	go indexer.ProcessDataFeed(consumer, txFeed, logsdb, quit, cfg.Eip155Block, cfg.HomesteadBlock, mut, cfg.MempoolSlots, indexes, hc, cfg.MemTxTimeThreshold)
 
 	tm := rpcTransports.NewTransportManager(cfg.Concurrency)
 	tm.RegisterHealthCheck(hc)

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -351,6 +351,23 @@ func MigrateMempool(db *sql.DB, chainid uint64) error {
 		log.Info("mempool migrations v1 done")
 	}
 
+	if schemaVersion < 2 {
+		log.Info("Applying mempool v2 migration")
+
+		if _, err := db.Exec(`ALTER TABLE mempool.transactions ADD time BIGINT;`); err != nil {
+			log.Error("migrations, mempool ALTER TABLE ADD time error", "err", err.Error())
+			return nil
+		}
+		if _, err := db.Exec(`CREATE INDEX mempool.time ON transactions(time);`); err != nil {
+			log.Error("migrations CREATE INDEX mempool.time error", "err", err.Error())
+			return nil
+		}
+		if _, err := db.Exec("UPDATE mempool.migrations SET version = 2;"); err != nil {
+			log.Error("migrations UPDATE mempool.migrations v2 error", "err", err.Error())
+		}
+		log.Info("mempool v2 migrations done")
+	}
+
 	log.Info("mempool migrations up to date")
 	return nil
 }


### PR DESCRIPTION
A time field was added to mempool transactions. Migrated, indexed, evaluated and acted upon by extending the existing mempool pruning function and piggy backing on the existing mempool pruning timer.