### PR TITLE
Added uncertainty check.

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 	genesisIndex := flag.Bool("genesisIndex", false, "index from zero")
 	lightSeed := flag.Int64("lightSeed", 0, "set light service starting block")
 	blockRollback := flag.Int64("block.rollback", 0, "Rollback to block N before syncing. If N < 0, rolls back from head before starting or syncing.")
-	skipCertainty := flag.Bool("skipCertainty", false, "skip database uncertainty check")
+	runCertaintyCheck := flag.Bool("certaintyCheck", false, "run database uncertainty check")
 
 	flag.CommandLine.Parse(os.Args[1:])
 
@@ -101,7 +101,7 @@ func main() {
 	}
 	_, hasBlocks := cfg.Databases["blocks"]
 	if hasBlocks {
-		if !*skipCertainty {
+		if *runCertaintyCheck {
 			rows, err := logsdb.QueryContext(context.Background(), "SELECT number + 1 FROM blocks WHERE number + 1 NOT IN (SELECT number FROM blocks.blocks);")		
 			if err != nil {
 				log.Error("Error occured when running certainty check on blocks database", "err", err)

--- a/main.go
+++ b/main.go
@@ -108,7 +108,10 @@ func main() {
 			}
 			defer rows.Close()
 			if rows.Next() {
-				log.Error("gaps found in blocks database", "missing blocks", rows)
+				var number uint64
+				rows.Scan(&number) 
+				log.Error("gaps found in blocks database", "missing blocks beginning at block number", number)
+				os.Exit(1)
 			}
 		}
 		log.Info("has blocks", "blocks", cfg.Databases["blocks"])


### PR DESCRIPTION
At this point the check will only work on flume instances with attached block databases. Also the check is rudementary in that it only scans for missing blocks or block ranges. Thus we are assuming that if there are no blocks missing then the other data is present as well.