### PR TITLE
Added a simple block time meter to indexer.

### DIFF
--- a/indexer/indexer.go
+++ b/indexer/indexer.go
@@ -184,6 +184,8 @@ func (hc *HealthCheck) Healthy() rpc.HealthStatus {
 
 func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *sql.DB, quit <-chan struct{}, eip155Block, homesteadBlock uint64, mut *sync.RWMutex, mempoolSlots int, indexers []Indexer, hc *HealthCheck, memTxThreshold int64, rhf chan int64) {
 	heightGauge := metrics.NewMajorGauge("/flume/height")
+	blockTimeMeter  := metrics.NewMajorMeter("/flume/blockTime")
+
 	log.Info("Processing data feed")
 	txCh := make(chan *evm.Transaction, 200)
 	txSub := txFeed.Subscribe(txCh)
@@ -273,8 +275,7 @@ func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *
 					mut.Unlock()
 					continue
 				}
-				// log.Printf("Spent %v on %v inserts", time.Since(istart), len(statements))
-				// cstart := time.Now()
+				cstart := time.Now()
 				if err := dbtx.Commit(); err != nil {
 					stats := db.Stats()
 					log.Warn("Failed to commit", "err", err.Error())
@@ -288,8 +289,9 @@ func ProcessDataFeed(csConsumer transports.Consumer, txFeed *txfeed.TxFeed, db *
 				rhf <- lastBatch.Number
 				hc.processedCount++
 				heightGauge.Update(lastBatch.Number)
-				// completionFeed.Send(chainEvent.Block.Hash)
-				// log.Printf("Spent %v on commit", time.Since(cstart))
+				if time.Since(cstart) > 10 * time.Second {
+					blockTimeMeter.Mark(1)
+				}
 				if blockTime != nil && time.Since(*blockTime) > time.Minute {
 					log.Info("Committed Block", "number", uint64(lastBatch.Number), "hash", hexutil.Bytes(lastBatch.Hash.Bytes()), "in", time.Since(start), "age", time.Since(*blockTime))
 					break


### PR DESCRIPTION
This implementation is very basic at this point. Essentially, if block processing time is greater than ten seconds we mark a tally on a metric.