### PR TITLE
Changes to api/uitls to accomodate for post blaster databases

### DIFF
--- a/api/block.go
+++ b/api/block.go
@@ -381,7 +381,7 @@ func (api *BlockAPI) GetBlockReceipts(ctx context.Context, input BlockNumberOrHa
 			blockNumber = rpc.BlockNumber(latestBlock)
 		}
 	
-		receipts, err := getFlumeTransactionReceiptsBlock(ctx, api.db, 0, 100000, api.network, "block = ?", uint64(blockNumber))
+		receipts, err := getTransactionReceipts(ctx, api.db, 0, 100000, api.network, "block = ?", uint64(blockNumber))
 		if err != nil {
 			log.Error("Error getting receipts, eth_getBlockReciepts, blockNumber", "err", err)
 			return nil, nil
@@ -417,7 +417,7 @@ func (api *BlockAPI) GetBlockReceipts(ctx context.Context, input BlockNumberOrHa
 			gbrHitMeter.Mark(1)
 		}
 	
-		receipts, err := getFlumeTransactionReceiptsBlock(ctx, api.db, 0, 100000, api.network, "blocks.hash = ?", trimPrefix(blockHash.Bytes()))
+		receipts, err := getTransactionReceipts(ctx, api.db, 0, 100000, api.network, "blocks.hash = ?", trimPrefix(blockHash.Bytes()))
 		if err != nil {
 			log.Error("Error getting receipts, eth_getBlockReciepts, blockHash", "err", err)
 			return nil, nil

--- a/api/flume.go
+++ b/api/flume.go
@@ -115,7 +115,7 @@ func (api *FlumeAPI) GetTransactionReceiptsBySender(ctx context.Context, address
 	if offset == nil {
 		offset = new(int)
 	}
-	receipts, err := getFlumeTransactionReceipts(ctx, api.db, *offset, 1000, api.network, "sender = ?", trimPrefix(address.Bytes()))
+	receipts, err := getTransactionReceipts(ctx, api.db, *offset, 1000, api.network, "sender = ?", trimPrefix(address.Bytes()))
 	if err != nil {
 		log.Error("Error getting receipts", "err", err.Error())
 		return nil, err
@@ -177,7 +177,7 @@ func (api *FlumeAPI) GetTransactionReceiptsByRecipient(ctx context.Context, addr
 	if offset == nil {
 		offset = new(int)
 	}
-	receipts, err := getFlumeTransactionReceipts(ctx, api.db, *offset, 1000, api.network, "recipient = ?", trimPrefix(address.Bytes()))
+	receipts, err := getTransactionReceipts(ctx, api.db, *offset, 1000, api.network, "recipient = ?", trimPrefix(address.Bytes()))
 	if err != nil {
 		log.Error("Error getting receipts", "err", err.Error())
 		return nil, err
@@ -239,7 +239,7 @@ func (api *FlumeAPI) GetTransactionReceiptsByParticipant(ctx context.Context, ad
 	if offset == nil {
 		offset = new(int)
 	}
-	receipts, err := getFlumeTransactionReceipts(ctx, api.db, *offset, 1000, api.network, "sender = ? OR recipient = ?", trimPrefix(address.Bytes()), trimPrefix(address.Bytes()))
+	receipts, err := getTransactionReceipts(ctx, api.db, *offset, 1000, api.network, "sender = ? OR recipient = ?", trimPrefix(address.Bytes()), trimPrefix(address.Bytes()))
 	if err != nil {
 		log.Error("Error getting receipts", "err", err.Error())
 		return nil, err
@@ -276,7 +276,7 @@ func (api *FlumeAPI) GetTransactionReceiptsByBlockHash(ctx context.Context, bloc
 		gtrbhHitMeter.Mark(1)
 	}
 
-	receipts, err := getFlumeTransactionReceiptsBlock(ctx, api.db, 0, 100000, api.network, "blocks.hash = ?", trimPrefix(blockHash.Bytes()))
+	receipts, err := getTransactionReceipts(ctx, api.db, 0, 100000, api.network, "blocks.hash = ?", trimPrefix(blockHash.Bytes()))
 	if err != nil {
 		log.Error("Error getting receipts, flume_getTransactionReceiptsByBlockHash", "err", err)
 		return nil, err
@@ -317,7 +317,7 @@ func (api *FlumeAPI) GetTransactionReceiptsByBlockNumber(ctx context.Context, bl
 		blockNumber = rpc.BlockNumber(latestBlock)
 	}
 
-	receipts, err := getFlumeTransactionReceiptsBlock(ctx, api.db, 0, 100000, api.network, "block = ?", uint64(blockNumber))
+	receipts, err := getTransactionReceipts(ctx, api.db, 0, 100000, api.network, "block = ?", uint64(blockNumber))
 	if err != nil {
 		log.Error("Error getting receipts, flume_getTransactionReceiptsByBlockNumber", "err", err)
 		return nil, err

--- a/api/transaction.go
+++ b/api/transaction.go
@@ -200,11 +200,17 @@ func (api *TransactionAPI) GetTransactionReceipt(ctx context.Context, txHash typ
 	})
 
 	var err error
-	receipts, err := getTransactionReceiptsBlock(ctx, api.db, 0, 1, api.network, "transactions.hash = ?", trimPrefix(txHash.Bytes()))
+	receipts, err := getTransactionReceipts(ctx, api.db, 0, 1, api.network, "transactions.hash = ?", trimPrefix(txHash.Bytes()))
 	if err != nil {
 		return nil, err
 	}
 	result := returnSingleReceipt(receipts)
+
+	for k, _ := range result {
+		if k =="timestamp" {
+			delete(result, k)
+		}
+	}
 
 	for _, fni := range pluginMethods {
 		fn := fni.(func(map[string]interface{}, types.Hash, *sql.DB) (map[string]interface{}, error))

--- a/indexer/mempool_indexer.go
+++ b/indexer/mempool_indexer.go
@@ -84,10 +84,13 @@ func mempool_indexer(db *sql.DB, mempoolSlots int, txDedup map[types.Hash]struct
 	// Delete the transaction we just inserted if the confirmed transactions
 	// pool has a conflicting entry
 	statements = append(statements, ApplyParameters(
-		"DELETE FROM mempool.transactions WHERE sender = %v AND nonce = %v AND (sender, nonce) IN (SELECT sender, nonce FROM transactions)",
+		"DELETE FROM mempool.transactions WHERE sender = %v AND nonce = %v AND (sender, nonce) IN (SELECT sender, nonce FROM transactions.transactions WHERE sender = %v AND nonce = %v)",
+		sender,
+		tx.Nonce(),
 		sender,
 		tx.Nonce(),
 	))
+
 	if _, err := db.Exec(strings.Join(statements, " ; ") + ";"); err != nil {
 		log.Error("Error on insert:", strings.Join(statements, " ; "), "err", err.Error())
 		return []string{}

--- a/indexer/tx_indexer.go
+++ b/indexer/tx_indexer.go
@@ -157,7 +157,9 @@ func (indexer *TxIndexer) Index(pb *delivery.PendingBatch) ([]string, error) {
 		))
 		if indexer.hasMempool {
 			statements = append(statements, ApplyParameters(
-				"DELETE FROM mempool.transactions WHERE sender = %v AND nonce = %v AND (sender, nonce) IN (SELECT sender, nonce FROM transactions.transactions INDEXED BY senderNonce)",
+				"DELETE FROM mempool.transactions WHERE sender = %v AND nonce = %v AND (sender, nonce) IN (SELECT sender, nonce FROM transactions.transactions WHERE sender = %v AND nonce = %v)",
+				sender,
+				transaction.Nonce(),
 				sender,
 				transaction.Nonce(),
 			))


### PR DESCRIPTION
Initially we had four different receipt acquisition functions. Those have been distilled down to one function to serve all receipt returning api methods.