### PR TITLE
Add response to error log when marshalling fails

### DIFF
--- a/heavy/heavy.go
+++ b/heavy/heavy.go
@@ -84,7 +84,7 @@ func callHeavy[T any](ctx context.Context, backendURL string, cutoffBlock *uint6
 	}
 	response := &rpc.RawResponse{}
 	if err := json.Unmarshal(result, &response); err != nil {
-		log.Error("callHeavy result unmarshalling error", "err", err)
+		log.Error("callHeavy result unmarshalling error", "err", err, "response", string(result))
 		return nil, rpc.NewRPCError(-32500, genericError)
 	}
 	if response.Error != nil {


### PR DESCRIPTION
If a callHeavy response fails to parse, we can often assume we got an HTML response from an "invalid character '<'" error message, but that doesn't tell us what the actual failure was.

This will put the whole message in the log.